### PR TITLE
Multiple-answer problems need `assert!(matches!(expr, pat | pat)`

### DIFF
--- a/leetcode/src/00451_sort_characters_by_frequency/solution.rs
+++ b/leetcode/src/00451_sort_characters_by_frequency/solution.rs
@@ -23,13 +23,13 @@ mod tests {
 
     #[test]
     fn test() {
-        let s = String::from("tree");
-        assert_eq!(Solution::frequency_sort(s), String::from("eert"));
+        let s = Solution::frequency_sort("tree".to_string());
+        assert!(matches!(&*s, "eert" | "eetr"));
 
-        let s = String::from("cccaaa");
-        assert_eq!(Solution::frequency_sort(s), String::from("aaaccc"));
+        let s = Solution::frequency_sort("cccaaa".to_string());
+        assert!(matches!(&*s, "aaaccc" | "cccaaa"));
 
-        let s = String::from("Aabb");
-        assert_eq!(Solution::frequency_sort(s), String::from("bbAa"));
+        let s = Solution::frequency_sort("Aabb".to_string());
+        assert!(matches!(&*s, "bbAa" | "bbaA"));
     }
 }


### PR DESCRIPTION
I rewrote some test code here to use patterns in the asserts so that it is correct [even if the sort ordering generated by `sort_unstable_by` changes](https://github.com/rust-lang/rust/pull/124032).